### PR TITLE
s3-workspace-policy fixed to scope for object level permissions

### DIFF
--- a/templates/aws/policies/s3-workspace-policy.json
+++ b/templates/aws/policies/s3-workspace-policy.json
@@ -9,7 +9,7 @@
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:{{ .region }}:{{ .accountID }}:accesspoint/{{ .accessPointName }}/object/{{ .path }}",
+                "arn:aws:s3:{{ .region }}:{{ .accountID }}:accesspoint/{{ .accessPointName }}/object/{{ .path }}*",
                 "arn:aws:s3:::{{ .bucketName }}/{{ .path }}*"
             ]
         },
@@ -22,7 +22,7 @@
             "Condition": {
                 "StringLike": {
                     "s3:prefix": [
-                        "{{ .path }}"
+                        "{{ .path }}*"
                     ]
                 }
             }

--- a/templates/aws/policies/s3-workspace-policy.json
+++ b/templates/aws/policies/s3-workspace-policy.json
@@ -6,17 +6,23 @@
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject",
-                "s3:DeleteObject",
-                "s3:ListBucket"
+                "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:{{ .region }}:{{ .accountID }}:accesspoint/{{ .accessPointName }}",
-                "arn:aws:s3:::{{ .bucketName }}"
+                "arn:aws:s3:{{ .region }}:{{ .accountID }}:accesspoint/{{ .accessPointName }}/object/{{ .path }}",
+                "arn:aws:s3:::{{ .bucketName }}/{{ .path }}*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
             ],
+            "Resource": "arn:aws:s3:::{{ .bucketName }}",
             "Condition": {
                 "StringLike": {
                     "s3:prefix": [
-                        "{{ .path }}*"
+                        "{{ .path }}"
                     ]
                 }
             }


### PR DESCRIPTION
Previously, the old policy did not properly scope object-level permissions to a specific prefix. These actions were applied broadly to the entire bucket or access point, meaning:

- It lacked a specific resource ARN for objects like `arn:aws:s3:::workspaces-eodhp-dev/jlangstone-tpzuk/*`.
- The condition `s3:prefix` only applied to `ListBucket`, not the object-level actions.

As a result, you couldn't access objects under `jlangstone-tpzuk/*` because the policy failed to define object-level permissions for that exact prefix. 

This seems to be one of the issues SparkGeo are having.