### PR TITLE
Increase default access points returned

### DIFF
--- a/internal/aws/efs.go
+++ b/internal/aws/efs.go
@@ -119,7 +119,7 @@ func (r *EFSReconciler) Teardown(ctx context.Context,
 
 func (r *EFSReconciler) ReconcileEFSAccessPoint(ctx context.Context,
 	efsAccess corev1alpha1.EFSAccess) (*string, error) {
-
+	
 	log := log.FromContext(ctx)
 
 	// Create a new EFS service client
@@ -128,6 +128,7 @@ func (r *EFSReconciler) ReconcileEFSAccessPoint(ctx context.Context,
 	// Get the access point
 	describeAccessPointsParams := &efs.DescribeAccessPointsInput{
 		FileSystemId: aws.String(efsAccess.FSID),
+		MaxResults:   aws.Int64(10000),
 	}
 	accessPoints, err := svc.DescribeAccessPoints(describeAccessPointsParams)
 	if err != nil {


### PR DESCRIPTION
This change modifies the EFS reconciler to set the `MaxResults` parameter in the `DescribeAccessPoints` API call to 10000. 

Previously, the API used the default value of 100, which caused problems whereby redundant access points were created because the desired access point wasn't found in the limited result set.

Pagination could be implemented but it introduces additional overhead to reconciliation logic (imo - maybe we should though for scalability?) and our access point struct doesn't hold the access point ID (only file system ID), hence we cannot add this to the `DescribeAccessPoints` param.

Testing:
- Creating a new workspace via our API and looking at the controllers logs
- Verifying only 1 access point is in the AWS records (via the UI)