### PR TITLE
Feature/eodhp 697 user creates workspaces

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -113,6 +113,12 @@ type WorkspaceStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// Workspace Status
+	State string `json:"state,omitempty"`
+
+	// Workspace Error Description
+	ErrorDescription string `json:"errorDescription,omitempty"`
+
 	// Name of child namespace
 	Namespace string `json:"namespace,omitempty"`
 	// AWS status

--- a/chart/workspace-operator/Chart.yaml
+++ b/chart/workspace-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2-rc1
+version: 0.4.2-rc4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/workspace-operator/templates/workspace-crd.yaml
+++ b/chart/workspace-operator/templates/workspace-crd.yaml
@@ -214,6 +214,12 @@ spec:
               namespace:
                 description: Name of child namespace
                 type: string
+              errorDescription:
+                description: Workspace Error Description
+                type: string
+              state:
+                description: Workspace Status
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/core.telespazio-uk.io_workspaces.yaml
+++ b/config/crd/bases/core.telespazio-uk.io_workspaces.yaml
@@ -210,8 +210,14 @@ spec:
                         type: array
                     type: object
                 type: object
+              errorDescription:
+                description: Workspace Error Description
+                type: string
               namespace:
                 description: Name of child namespace
+                type: string
+              state:
+                description: Workspace Status
                 type: string
             type: object
         type: object

--- a/internal/aws/efs.go
+++ b/internal/aws/efs.go
@@ -159,7 +159,7 @@ func (r *EFSReconciler) ReconcileEFSAccessPoint(ctx context.Context,
 
 		// Check if there are more pages
 		if accessPoints.NextToken == nil {
-			break 
+			break
 		}
 
 		// Update the nextToken for the next request


### PR DESCRIPTION
- Added `state` and `errorDescription` to the Workspace status CRD.

This CRD state can be either `Ready` or `Error`. If `Error`, an `ErrorDescription` will be shown in the status and will help with debugging. Only the `state` will be propagated to end users. 

- Required a new helm version (to update the CRD) + controller

Testing with existing workspaces, editing the spec and seeing the resulting error descriptions + reverting and seeing the state change as a result. 