### PR TITLE
Add second service account match to allow user services to assume the…

### DIFF
--- a/templates/aws/policies/s3-workspace-policy.json
+++ b/templates/aws/policies/s3-workspace-policy.json
@@ -16,6 +16,15 @@
         {
             "Effect": "Allow",
             "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::{{ .bucketName }}/workflow-harvester/*/{{ .path }}*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "s3:ListBucket"
             ],
             "Resource": "arn:aws:s3:::{{ .bucketName }}",

--- a/templates/aws/policies/trust-policy.json
+++ b/templates/aws/policies/trust-policy.json
@@ -10,8 +10,11 @@
                 "sts:AssumeRoleWithWebIdentity"
             ],
             "Condition": {
-                "StringEquals": {
-                    "{{.oidc.provider}}:sub": "system:serviceaccount:{{.namespace}}:{{.serviceAccount}}"
+                "StringLike": {
+                    "{{.oidc.provider}}:sub": [
+                        "system:serviceaccount:{{.namespace}}:{{.serviceAccount}}",
+                        "system:serviceaccount:ws-*:temp-{{.namespace}}-*"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## Allow access to role via service account in additional workspaces
- Adding a new service account using wildcards
- This service account will be generated in the calling-workspace for any user service execution requests
- The additional service account will be in the executing workspace namespace, `ws-<executing-workspace>`, and will be assigned the name starting with `temp-<calling-namespace>`
- This ensures user-services can load and export data to the calling workspace, via this service account