### PR TITLE
Bugfix/eodhp 1328 delete workspace

### DIFF
--- a/chart/workspace-operator/Chart.yaml
+++ b/chart/workspace-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2-rc6
+version: 0.4.3-rc1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/workspace-operator/templates/manager-rbac.yaml
+++ b/chart/workspace-operator/templates/manager-rbac.yaml
@@ -115,6 +115,16 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/aws/efs.go
+++ b/internal/aws/efs.go
@@ -109,8 +109,7 @@ func (r *EFSReconciler) Teardown(ctx context.Context,
 			log.Info("Deleted EFS Access Point",
 				"access point ID", efsStatus.AccessPointID)
 		} else {
-			log.Info("Failed to delete EFS Access Point",
-				"access point ID", efsStatus.AccessPointID)
+			log.Error(err, "Failed to delete EFS Access Point", "access point ID", efsStatus.AccessPointID)
 		}
 	}
 

--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -236,49 +236,6 @@ func (r *S3Reconciler) DeleteS3PolicyFromRole(ctx context.Context,
 	return nil
 }
 
-// func (r *S3Reconciler) DeleteS3Prefix(ctx context.Context,
-// 	bucket *corev1alpha1.S3Bucket,
-// 	status *corev1alpha1.S3BucketStatus) error {
-
-// 	log := log.FromContext(ctx)
-// 	svc := s3.New(r.AWS.sess)
-
-// 	// Safety check: skip if prefix is empty or root
-// 	if bucket.Path == "" || bucket.Path == "/" {
-// 		log.Error(nil, "Skipping prefix processing: empty or root prefix", "bucket", bucket.Name, "prefix", bucket.Path)
-// 		return nil
-// 	}
-
-// 	// List objects in the prefix
-// 	listInput := &s3.ListObjectsV2Input{
-// 		Bucket: aws.String(bucket.Name),
-// 		Prefix: aws.String(bucket.Path),
-// 	}
-
-// 	// Iterate through objects and log them without deleting
-// 	err := svc.ListObjectsV2Pages(listInput, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
-// 		if page == nil || len(page.Contents) == 0 {
-// 			log.Info("No objects found in S3 prefix", "bucket", bucket.Name, "prefix", bucket.Path)
-// 			return false
-// 		}
-
-// 		// Log each object that would be deleted
-// 		for _, obj := range page.Contents {
-// 			log.Info("Object to be deleted", "bucket", bucket.Name, "prefix", bucket.Path, "key", *obj.Key)
-// 		}
-
-// 		return true
-// 	})
-
-// 	if err != nil {
-// 		log.Error(err, "Failed to list objects for prefix", "bucket", bucket.Name, "prefix", bucket.Path)
-// 		return err
-// 	}
-
-// 	log.Info("Completed logging objects in S3 prefix without deletion", "bucket", bucket.Name, "prefix", bucket.Path)
-// 	return nil
-// }
-
 func (r *S3Reconciler) DeleteS3Prefix(ctx context.Context,
 	bucket *corev1alpha1.S3Bucket,
 	status *corev1alpha1.S3BucketStatus) error {

--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -108,6 +108,11 @@ func (r *S3Reconciler) Teardown(ctx context.Context,
 			}
 		}
 
+		// Delete the S3 prefix and its contents
+		if err := r.DeleteS3Prefix(ctx, &bucket, bucketStatus); err != nil {
+			log.Error(err, "Failed to delete S3 prefix", "bucket", bucket)
+		}
+
 	}
 	status.AWS.S3.Buckets = bucketStatuses
 	return nil
@@ -228,6 +233,119 @@ func (r *S3Reconciler) DeleteS3PolicyFromRole(ctx context.Context,
 	}
 
 	log.Info("Deleted inline policy from role", "policyName", policyName, "role", roleName)
+	return nil
+}
+
+// func (r *S3Reconciler) DeleteS3Prefix(ctx context.Context,
+// 	bucket *corev1alpha1.S3Bucket,
+// 	status *corev1alpha1.S3BucketStatus) error {
+
+// 	log := log.FromContext(ctx)
+// 	svc := s3.New(r.AWS.sess)
+
+// 	// Safety check: skip if prefix is empty or root
+// 	if bucket.Path == "" || bucket.Path == "/" {
+// 		log.Error(nil, "Skipping prefix processing: empty or root prefix", "bucket", bucket.Name, "prefix", bucket.Path)
+// 		return nil
+// 	}
+
+// 	// List objects in the prefix
+// 	listInput := &s3.ListObjectsV2Input{
+// 		Bucket: aws.String(bucket.Name),
+// 		Prefix: aws.String(bucket.Path),
+// 	}
+
+// 	// Iterate through objects and log them without deleting
+// 	err := svc.ListObjectsV2Pages(listInput, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+// 		if page == nil || len(page.Contents) == 0 {
+// 			log.Info("No objects found in S3 prefix", "bucket", bucket.Name, "prefix", bucket.Path)
+// 			return false
+// 		}
+
+// 		// Log each object that would be deleted
+// 		for _, obj := range page.Contents {
+// 			log.Info("Object to be deleted", "bucket", bucket.Name, "prefix", bucket.Path, "key", *obj.Key)
+// 		}
+
+// 		return true
+// 	})
+
+// 	if err != nil {
+// 		log.Error(err, "Failed to list objects for prefix", "bucket", bucket.Name, "prefix", bucket.Path)
+// 		return err
+// 	}
+
+// 	log.Info("Completed logging objects in S3 prefix without deletion", "bucket", bucket.Name, "prefix", bucket.Path)
+// 	return nil
+// }
+
+func (r *S3Reconciler) DeleteS3Prefix(ctx context.Context,
+	bucket *corev1alpha1.S3Bucket,
+	status *corev1alpha1.S3BucketStatus) error {
+
+	log := log.FromContext(ctx)
+	svc := s3.New(r.AWS.sess)
+
+	// List objects in the prefix
+	listInput := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket.Name),
+		Prefix: aws.String(bucket.Path),
+	}
+
+	// Iterate through objects and delete them
+	err := svc.ListObjectsV2Pages(listInput, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+		if page == nil || len(page.Contents) == 0 {
+			return false
+		}
+
+		// Prepare batch delete request
+		var objects []*s3.ObjectIdentifier
+		for _, obj := range page.Contents {
+			objects = append(objects, &s3.ObjectIdentifier{
+				Key: obj.Key,
+			})
+		}
+
+		// Delete objects in batch
+		deleteInput := &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucket.Name),
+			Delete: &s3.Delete{
+				Objects: objects,
+				Quiet:   aws.Bool(true),
+			},
+		}
+
+		_, err := svc.DeleteObjects(deleteInput)
+		if err != nil {
+			log.Error(err, "Failed to delete objects in prefix", "bucket", bucket.Name, "prefix", bucket.Path)
+			return false
+		}
+
+		return true
+	})
+
+	if err != nil {
+		log.Error(err, "Failed to list objects for deletion", "bucket", bucket.Name, "prefix", bucket.Path)
+		return err
+	}
+
+	// Explicitly delete the prefix object if it exists
+	_, err = svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(bucket.Name),
+		Key:    aws.String(bucket.Path),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NoSuchKey" {
+			log.Info("No prefix object to delete", "bucket", bucket.Name, "prefix", bucket.Path)
+		} else {
+			log.Error(err, "Failed to delete prefix object", "bucket", bucket.Name, "prefix", bucket.Path)
+			return err
+		}
+	} else {
+		log.Info("Deleted S3 prefix object", "bucket", bucket.Name, "prefix", bucket.Path)
+	}
+
+	log.Info("Completed deletion of S3 prefix and its contents", "bucket", bucket.Name, "prefix", bucket.Path)
 	return nil
 }
 

--- a/internal/controller/storage.go
+++ b/internal/controller/storage.go
@@ -62,7 +62,7 @@ func (r *StorageReconciler) Teardown(
 	log := log.FromContext(ctx)
 
 	if err := r.DeleteBlockStoreData(ctx, spec, status); err != nil {
-		log.Error(err, "Failed to teardown persistent volumes")
+		log.Error(err, "Failed to delete block store data")
 	}
 
 	if err := r.DeletePersistentVolumes(ctx, spec, status); err != nil {

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -18,13 +18,18 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"reflect"
+	"time"
 
 	corev1alpha1 "github.com/EO-DataHub/eodhp-workspace-controller/api/v1alpha1"
 	"github.com/EO-DataHub/eodhp-workspace-controller/internal/aws"
 	"gopkg.in/yaml.v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,6 +123,7 @@ type Reconciler interface {
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -180,7 +186,25 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context,
 			}
 		}
 	} else {
-		// Workspace is being deleted, teardown dependents
+		// Workspace is being deleted,
+
+		// Run cleanup job before teardown
+		// We need to do this before we remove the finalizer as the job won't start if the namespace is in a terminating state
+		log.Info("Workspace is being deleted, running delete data job")
+		done, err := r.deleteData(ctx, ws)
+		if err != nil {
+			sts.State = StateError
+			sts.ErrorDescription = "Delete data job failed: " + err.Error()
+			_, _ = r.UpdateStatus(ctx, req, sts)
+			return ctrl.Result{}, err
+		}
+		if !done {
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
+		log.Info("Delete data job completed successfully, proceeding with teardown")
+
+		// teardown dependents
 		for _, reconciler := range reverse(r.reconcilers) {
 
 			reconcilerName := reflect.TypeOf(reconciler).String()
@@ -318,4 +342,78 @@ func (c *Config) Load(path string) error {
 	}
 
 	return nil
+}
+
+// deleteData runs a cleanup job to delete workspace data.
+// It checks if the job exists, creates it if not, and monitors its status.
+// Returns true if the job completed successfully, false if still running, or an error if it failed.
+// The job deletes all data in the workspace's PVC.
+func (r *WorkspaceReconciler) deleteData(ctx context.Context, ws *corev1alpha1.Workspace) (bool, error) {
+	log := log.FromContext(ctx)
+	jobName := "delete-data-" + ws.Name
+	jobNamespace := "ws-" + ws.Name
+
+	job := &batchv1.Job{}
+	err := r.Get(ctx, client.ObjectKey{Name: jobName, Namespace: jobNamespace}, job)
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Delete data Job not found, creating new one", "job", jobName, "namespace", jobNamespace)
+
+			newJob := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: jobNamespace,
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{{
+								Name:    "cleanup",
+								Image:   "busybox",
+								Command: []string{"sh", "-c", "rm -rf /workspace/*"},
+								VolumeMounts: []corev1.VolumeMount{{
+									Name:      "workspace-data",
+									MountPath: "/workspace",
+								}},
+							}},
+							Volumes: []corev1.Volume{{
+								Name: "workspace-data",
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "pvc-" + ws.Name,
+									},
+								},
+							}},
+						},
+					},
+				},
+			}
+
+			if err := r.Create(ctx, newJob); err != nil {
+				log.Error(err, "Failed to create delete data job", "job", jobName)
+				return false, fmt.Errorf("failed to create delete data job: %w", err)
+			}
+
+			log.Info("Delete data job created, waiting for completion", "job", jobName)
+			return false, nil
+		}
+
+		// Unexpected error fetching job
+		log.Error(err, "Failed to get delete data job", "job", jobName)
+		return false, err
+	}
+
+	// Job exists, check its status
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return false, fmt.Errorf("cleanup job failed")
+		}
+	}
+
+	return false, nil 
 }


### PR DESCRIPTION
- Added to `S3Reconciler` teardown to actually delete the S3 prefix
- Added to `StorageReconciler` teardown to delete the underlying data. This runs a K8s job that deletes contents from the mounted block. 

A proper infrastructure-driven deletion of the FSAP root directory wasn't achieved unfortunately (despite my best efforts / time restrictions) - so as a workaround a k8s job is launched to clean up volume contents before PVC deletion..


**How I tested block data deletion**
1. Created a workspace 
2. Opened notebooks in that workspace and added some files
3. Deleted the workspace - monitored the controller logs
4. Recreated the workspace under the same name
5. Opened notebooks for that workspace
6. Files no longer present